### PR TITLE
fix(config): apply AIBOMGEN_* env overrides regardless of --config path (#9)

### DIFF
--- a/cmd/aibomgen-cli/root.go
+++ b/cmd/aibomgen-cli/root.go
@@ -67,6 +67,16 @@ func init() {
 }
 
 func initConfig() {
+	// Enable environment variable support (e.g. AIBOMGEN_HUGGINGFACE_TOKEN)
+	// up-front so overrides apply regardless of how (or whether) the config
+	// file is located below. Previously this block only ran in the
+	// `cfgFile != ""` branch, so users without `--config` silently lost all
+	// AIBOMGEN_* env vars (issue #9). Replace dots with underscores:
+	// huggingface.token -> AIBOMGEN_HUGGINGFACE_TOKEN.
+	viper.SetEnvPrefix("AIBOMGEN")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
@@ -101,12 +111,6 @@ func initConfig() {
 
 		return
 	}
-
-	// Enable environment variable support (e.g., AIBOMGEN_HUGGINGFACE_TOKEN).
-	// Replace dots with underscores: huggingface.token -> AIBOMGEN_HUGGINGFACE_TOKEN.
-	viper.SetEnvPrefix("AIBOMGEN")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.AutomaticEnv()
 
 	err := viper.ReadInConfig()
 


### PR DESCRIPTION
## Summary

\`SetEnvPrefix\` / \`SetEnvKeyReplacer\` / \`AutomaticEnv\` only ran inside the \`cfgFile != \"\"\` branch of \`initConfig\`. Users running \`aibomgen-cli\` without \`--config\` fell into the \`else\` branch, which \`return\`-s early and never enables the env-var bridge — so every \`AIBOMGEN_*\` variable (e.g. \`AIBOMGEN_HUGGINGFACE_TOKEN\`) was silently ignored and requests went out unauthenticated.

Reproducer from the issue:

\`\`\`
AIBOMGEN_SCAN_HF_TOKEN=my-token aibomgen-cli scan --input ./my-project --output out.json
\`\`\`

## Fix

Move \`SetEnvPrefix\` / \`SetEnvKeyReplacer\` / \`AutomaticEnv\` to the top of \`initConfig\`, before the \`cfgFile\` switch, so env overrides are live regardless of how (or whether) the config file is located.

Fixes #9

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] Traced both branches: with \`--config\`, env bridge is set once up-front and still active; without \`--config\`, bridge is now set before the early \`return\` so \`AIBOMGEN_*\` values reach viper